### PR TITLE
feat: temporarily disable sponsor section

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -7,7 +7,7 @@ import LandingHeroPage from '../landing-hero-page/landing-hero-page';
 import Schedule from '../schedule/schedule';
 import { EVENTS } from '../schedule/schedule-data';
 import Speakers from '../speakers/speakers';
-import Partners from '../sponsors/sponsors';
+// import Partners from '../sponsors/sponsors';
 import StickyNavBar from '../sticky-navbar/sticky-navbar';
 import './app.scss';
 
@@ -20,7 +20,8 @@ const App: FunctionComponent = () => (
     <Schedule events={EVENTS} />
     <Speakers />
     <Faq questionAnswers={QUESTION_ANSWERS} />
-    <Partners />
+    {/* TODO: Re-enable sponsors section once content is ready */}
+    {/* <Partners /> */}
 
     <Footer />
   </div>

--- a/src/components/sticky-navbar/sticky-navbar.tsx
+++ b/src/components/sticky-navbar/sticky-navbar.tsx
@@ -104,6 +104,7 @@ const StickyNavBar: FunctionComponent = () => {
                 {t('App.schedule')}
               </Link>
             </li>
+            {/* TODO: Re-enable sponsor navigation once sponsors section returns
             <li>
               <Link
                 className="a"
@@ -114,6 +115,7 @@ const StickyNavBar: FunctionComponent = () => {
                 {t('App.sponsors')}
               </Link>
             </li>
+            */}
             <li>
               <a className="a" href={t('App.sponsorus.link')}>
                 {t('App.sponsorus')}


### PR DESCRIPTION
## Summary
- hide sponsors component and navigation
- note TODO to restore sponsor section later

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60dad7448832093c02b0a1486dc0f