### PR TITLE
Apply dark blue site theme for improved readability

### DIFF
--- a/src/components/resources/resources.scss
+++ b/src/components/resources/resources.scss
@@ -28,21 +28,21 @@
   }
 }
 
-.resource-card {
-  background: #222;
-  border-radius: 8px;
-  padding: 24px;
-  margin: 8px;
-  color: #fff; // White text
-  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
-  transition: transform 0.1s;
-}
-.resource-card:hover {
-  transform: translateY(-2px) scale(1.03);
-  background: #333;
-}
-.resource-title {
-  color: #fff; // Ensures white text
-  font-size: 1.1rem;
-  font-weight: 500;
-}
+  .resource-card {
+    background: rgba($background-dark, 0.8);
+    border-radius: 8px;
+    padding: 24px;
+    margin: 8px;
+    color: $text-light;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    transition: transform 0.1s;
+  }
+  .resource-card:hover {
+    transform: translateY(-2px) scale(1.03);
+    background: rgba($background-dark, 0.9);
+  }
+  .resource-title {
+    color: $text-light;
+    font-size: 1.1rem;
+    font-weight: 500;
+  }

--- a/src/components/speakers/speaker/speaker.scss
+++ b/src/components/speakers/speaker/speaker.scss
@@ -2,7 +2,10 @@
 .speaker {
     height: 300px;
     width: 300px;
-    background: transparent;
+    background-color: rgba($primary, 0.15);
+    border-radius: 8px;
+    padding: 1rem;
+
     .avatar {
         height: 200px;
         width: 200px;

--- a/src/components/speakers/speakers.scss
+++ b/src/components/speakers/speakers.scss
@@ -1,22 +1,27 @@
 @import '../../scss/variables.scss';
 .speakers {
-    background-color: $primary;
-    // height: 65vh;
+    background: transparent;
     width: 100%;
     padding: 5%;
     display: flex;
     flex-direction: column;
     justify-content: center;
+    color: $text-light;
+
     .speaker-wrapper {
         margin: auto;
         display: flex;
         width: min-content;
         padding-top: 10%;
         padding-bottom: 8px;
+        background-color: rgba($background-dark, 0.6);
+        border-radius: 8px;
     }
+
     .active {
         background-color: $primary;
     }
+
     h6 {
         color: $text-light;
         text-align: center;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,18 +1,18 @@
-$primary: #1E3A8A;
-$primary-lite: #3B82F6;
-$secondary: #F59E0B;
-$accent: #3b1f8e;
-$degrade: #64748B;
+$primary: #0d47a1;
+$primary-lite: #1976d2;
+$secondary: #1d4ed8;
+$accent: #1e40af;
+$degrade: #0a192f;
 
-$background-start: #081d55;
-$background-end: #082a60;
+$background-start: #0a192f;
+$background-end: #0f2f5a;
 
-$background-dark: #0F172A;
-$text-light: #F8FAFC;
-$text-muted: #6B7280;
-$highlight: #14B8A6;
-$highlight-light: #5EEAD4;
-$highlight-dark: #0F766E;
+$background-dark: #020617;
+$text-light: #f8fafc;
+$text-muted: #94a3b8;
+$highlight: #60a5fa;
+$highlight-light: #93c5fd;
+$highlight-dark: #1e3a8a;
 
 $font-family: 'Segoe UI', sans-serif;
 


### PR DESCRIPTION
## Summary
- Replace SCSS variables with a unified dark blue palette
- Restyle resource cards with translucent dark backgrounds and light text

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-slick' from 'src/components/resources/resources.tsx')*
- `npm run lint` *(fails: ordered-imports/trailing-comma issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9d38f0b48320a76c61e469020b89