### PR TITLE
Re-enable sponsors section

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -8,8 +8,8 @@ import Resources from '../resources/resources';
 import Schedule from '../schedule/schedule';
 import { EVENTS } from '../schedule/schedule-data';
 import Speakers from '../speakers/speakers';
+import Partners from '../sponsors/sponsors';
 import StickyNavBar from '../sticky-navbar/sticky-navbar';
-// import Partners from '../sponsors/sponsors';
 import './app.scss';
 
 const App: FunctionComponent = () => (
@@ -23,7 +23,7 @@ const App: FunctionComponent = () => (
     <Resources />
     <Faq questionAnswers={QUESTION_ANSWERS} />
     {/* TODO: Re-enable sponsors section once content is ready */}
-    {/* <Partners /> */}
+    <Partners />
 
     <Footer />
   </div>


### PR DESCRIPTION
## Summary
- restore the Partners component import in the app shell
- render the sponsors section between the FAQ and Footer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce14bff27883208c74c9b45f208013