### PR TITLE
Update sponsor gallery

### DIFF
--- a/src/components/sponsors/sponsors-data.tsx
+++ b/src/components/sponsors/sponsors-data.tsx
@@ -1,14 +1,13 @@
-// import AECSP from './img/AECSP.svg';
-import CN from './img/CN.png';
-import COVEO from './img/coveo.png';
-import DRUIDE from './img/druide.png';
-import ERICSON from './img/ericson.png';
-import GURU from './img/guru.png';
-import IVADO from './img/ivado.png';
-import POLY from './img/Polytechnique_logo.png';
-import SEMLA_LOGO from './img/semla_logo.png';
-import STINGRAY from './img/stingray.png';
-import TD from './img/td_logo.jpg';
+import AECSPPoster from '../../images/sponsors/AECSP.png';
+import BanqueNationalePoster from '../../images/sponsors/Banque_Nationale.png';
+import IRIUPoster from '../../images/sponsors/IRIU.png';
+import IvadoPoster from '../../images/sponsors/Ivado.png';
+import PactolePoster from '../../images/sponsors/Pactole.png';
+import PolyMTLPoster from '../../images/sponsors/PolyMTL.png';
+import PropolysPoster from '../../images/sponsors/Propolys.png';
+import SEMLAPoster from '../../images/sponsors/SEMLA.png';
+import TailedPoster from '../../images/sponsors/Tailed.png';
+import VidensPoster from '../../images/sponsors/Videns.png';
 
 export interface Sponsor {
   name: string;
@@ -16,64 +15,50 @@ export interface Sponsor {
   website?: string;
 }
 
-export const PLATINUM: Sponsor[] = [];
-
-export const GOLD: Sponsor[] = [
-
+export const SPONSORS: Sponsor[] = [
+  {
+    name: 'Banque Nationale',
+    imgPath: BanqueNationalePoster,
+    website: 'https://www.bnc.ca/',
+  },
   {
     name: 'IVADO',
-    imgPath: IVADO,
+    imgPath: IvadoPoster,
     website: 'https://ivado.ca/en/',
   },
   {
-    name: 'CN',
-    imgPath: CN,
-    website: 'https://www.cn.ca/en/',
-  },
-  {
     name: 'SEMLA',
-    imgPath: SEMLA_LOGO,
+    imgPath: SEMLAPoster,
     website: 'https://semla.quebec/en/',
   },
   {
-    name: 'ERICSON',
-    imgPath: ERICSON,
-    website: ' https://www.ericsson.com/en/newsroom/media-kits',
+    name: 'Polytechnique Montréal',
+    imgPath: PolyMTLPoster,
+    website: 'https://www.polymtl.ca/',
   },
- 
-  ];
-export const SILVER: Sponsor[] = [
   {
-    name: 'COVEO',
-    imgPath: COVEO,
-    website: 'https://www.coveo.com/en',
+    name: 'AECSP',
+    imgPath: AECSPPoster,
+    website: 'https://aecsp.qc.ca/',
+  },
+  {
+    name: 'Videns Analytics',
+    imgPath: VidensPoster,
+  },
+  {
+    name: 'Pactole',
+    imgPath: PactolePoster,
+  },
+  {
+    name: 'Tailed',
+    imgPath: TailedPoster,
+  },
+  {
+    name: 'Propolys',
+    imgPath: PropolysPoster,
+  },
+  {
+    name: 'IRIU',
+    imgPath: IRIUPoster,
   },
 ];
-export const BRONZE: Sponsor[] = [
-  { 
-    name: 'Druide', 
-    imgPath: DRUIDE, 
-    website: 'https://www.druide.com/en/', 
-  },
- /* { 
-    name: 'AECSP', 
-    imgPath: AECSP,
-     website: 'https://aecsp.qc.ca/', 
-    },*/
-  { name: 'Guru', imgPath: GURU, website: 'https://www.guruenergy.com/en-ca' },
-    {
-      name: 'Stingray',
-      imgPath: STINGRAY,
-      website: '  https://corporate.stingray.com/media-center/',
-    },
-    {
-      name: 'Teledyne Dalsa',
-      imgPath: TD,
-      website: 'https://www.teledynedalsa.com/en/home/',
-    },
-    {
-      name: 'Polytechnique Montreal',
-      imgPath: POLY,
-      website: 'https://www.polymtl.ca/',
-    },
-  ];

--- a/src/components/sponsors/sponsors.scss
+++ b/src/components/sponsors/sponsors.scss
@@ -1,67 +1,74 @@
-    @import '../../scss/variables.scss';
-    .partners-section {
-        padding-top: 5rem;
-        padding-bottom: 5rem;
-        background: $degrade;
-        background: linear-gradient(0deg, $degrade 0%, $primary 100%);
-    }
-    
-    .parters-center,
-    .center-logos {
+@import '../../scss/variables.scss';
+
+.partners-section {
+    padding-top: 5rem;
+    padding-bottom: 5rem;
+    background: $degrade;
+    background: linear-gradient(0deg, $degrade 0%, $primary 100%);
+}
+
+.sponsors-wrapper {
+    width: min(90%, 1100px);
+    margin: 0 auto;
+    padding-top: 2rem;
+}
+
+.sponsors-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.sponsor-card {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    padding: 1.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+
+    a {
         display: flex;
         align-items: center;
         justify-content: center;
-        padding-bottom: 20px;
+        width: 100%;
+        height: 100%;
     }
-    
-    .partners-logos-container {
-        padding-top: 10px;
-        width: 90%;
+
+    img {
+        width: 100%;
+        height: 100%;
+        max-height: 360px;
+        object-fit: contain;
     }
-    
-    .center-logos {
-        padding-bottom: 20px;
+
+    &:hover {
+        transform: translateY(-6px);
+        background: rgba(255, 255, 255, 0.12);
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
     }
-    
-    .sponsor-us-btn {
-        float: center;
-        transition: all 0.3s ease 0s;
-        padding: 1%;
-        background-color: $degrade;
-        color: $text-light;
-        font-size: 1.5vw;
-        border-radius: 12px;
-        outline: none;
-        border: none;
-        width: 15%;
-        a {
-            color: $text-light;
-            text-decoration: none;
-        }
-        &:hover {
-            width: 12%;
-            background-color: $highlight-light;
-            transition: all 0.6s ease 0s;
-            cursor: pointer;
-        }
+}
+
+@media screen and (max-width: 992px) {
+    .sponsors-grid {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1.5rem;
     }
-    
-    @media screen and (max-width: 768px) {
-        .sponsor-us-btn {
-            font-size: 2.5vw;
-            width: 20%;
-            &:hover {
-                width: 18%;
-            }
-        }
+
+    .sponsor-card {
+        padding: 1.5rem;
     }
-    
-    @media screen and (max-width: 600px) {
-        .sponsor-us-btn {
-            font-size: 4vw;
-            width: 30%;
-            &:hover {
-                width: 28%;
-            }
-        }
+}
+
+@media screen and (max-width: 576px) {
+    .sponsors-wrapper {
+        width: 95%;
+        padding-top: 1.5rem;
     }
+
+    .sponsor-card {
+        padding: 1.25rem;
+    }
+}

--- a/src/components/sponsors/sponsors.tsx
+++ b/src/components/sponsors/sponsors.tsx
@@ -1,43 +1,27 @@
 import React, { FunctionComponent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Col, Row } from 'reactstrap';
 import ContainerHeading from '../common/container-heading';
-import { BRONZE, GOLD, PLATINUM, SILVER, Sponsor } from './sponsors-data';
+import { SPONSORS } from './sponsors-data';
 import './sponsors.scss';
-
-const generateLogos = (xs: string, md: string, array: Sponsor[]) => {
-    return (
-        <Row xs={xs} md={md} className="parters-center">
-                {
-                    array.map( (sponsor: Sponsor, index: number) => {
-                        return (
-                            <Col key={index} className="center-logos">
-                                {sponsor.website ?
-                                    <a href={sponsor.website} target="_blank" rel="noopener noreferrer">
-                                        <img src={sponsor.imgPath} alt={sponsor.name} width="100%"/>
-                                    </a>
-                                    :
-                                    <img src={sponsor.imgPath} alt={sponsor.name} width="100%"/>
-                                }
-                            </Col>
-                        );
-                    })
-                }
-        </Row>
-    );
-};
 
 const Partners: FunctionComponent = () => {
     const { t } = useTranslation();
     return (
         <div className="partners-section" id="partners">
-            <ContainerHeading title={t('Partners.title')}/>
-            <div className="parters-center">
-                <div className="partners-logos-container">
-                    {generateLogos('1', '2', PLATINUM)}
-                    {generateLogos('2', '3', GOLD)}
-                    {generateLogos('3', '4', SILVER)}
-                    {generateLogos('4', '5', BRONZE)}
+            <ContainerHeading title={t('Partners.title')} />
+            <div className="sponsors-wrapper">
+                <div className="sponsors-grid">
+                    {SPONSORS.map((sponsor) => (
+                        <div key={sponsor.name} className="sponsor-card">
+                            {sponsor.website ? (
+                                <a href={sponsor.website} target="_blank" rel="noopener noreferrer">
+                                    <img src={sponsor.imgPath} alt={sponsor.name} loading="lazy" />
+                                </a>
+                            ) : (
+                                <img src={sponsor.imgPath} alt={sponsor.name} loading="lazy" />
+                            )}
+                        </div>
+                    ))}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the sponsor data with the new poster assets from `src/images/sponsors`
- render the sponsors as a responsive grid of poster cards
- refresh the sponsor section styling to support the new layout and hover effects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce15a64ad08320bce60695c6c94d4c